### PR TITLE
fix: temporarily enable public access for Form Recognizer and Content Safety

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1532,7 +1532,7 @@ module formrecognizer 'modules/core/ai/cognitiveservices.bicep' = {
     tags: allTags
     kind: 'FormRecognizer'
 
-    enablePrivateNetworking: enablePrivateNetworking
+    enablePrivateNetworking: false // Temporary: enabling public access to resolve 403 private endpoint errors
     enableMonitoring: enableMonitoring
     enableTelemetry: enableTelemetry
     subnetResourceId: enablePrivateNetworking ? virtualNetwork!.outputs.pepsSubnetResourceId : null
@@ -1583,7 +1583,7 @@ module contentsafety 'modules/core/ai/cognitiveservices.bicep' = {
     tags: allTags
     kind: 'ContentSafety'
 
-    enablePrivateNetworking: enablePrivateNetworking
+    enablePrivateNetworking: false // Temporary: enabling public access to resolve 403 private endpoint errors
     enableMonitoring: enableMonitoring
     enableTelemetry: enableTelemetry
     subnetResourceId: enablePrivateNetworking ? virtualNetwork!.outputs.pepsSubnetResourceId : null

--- a/infra/main.json
+++ b/infra/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.42.1.51946",
-      "templateHash": "2250711427691307859"
+      "templateHash": "16421140691716802279"
     }
   },
   "parameters": {
@@ -45989,7 +45989,7 @@
             "value": "FormRecognizer"
           },
           "enablePrivateNetworking": {
-            "value": "[parameters('enablePrivateNetworking')]"
+            "value": false
           },
           "enableMonitoring": {
             "value": "[parameters('enableMonitoring')]"
@@ -48407,7 +48407,7 @@
             "value": "ContentSafety"
           },
           "enablePrivateNetworking": {
-            "value": "[parameters('enablePrivateNetworking')]"
+            "value": false
           },
           "enableMonitoring": {
             "value": "[parameters('enableMonitoring')]"


### PR DESCRIPTION
## Purpose
* Temporarily enable public access for Form Recognizer (Document Intelligence) and Content Safety to resolve 403 private endpoint errors during file upload and chat.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## How to Test
* Get the code

\\\
git clone https://github.com/Abdul-Microsoft/chat-with-your-data-solution-accelerator.git
cd chat-with-your-data-solution-accelerator
git checkout fix/temp-public-access-cognitive-services
\\\

* Test the code
\\\
azd up
\\\

## What to Check
Verify that the following are valid
* File upload (PDF) completes without 403 errors
* Chat responses work without Content Safety 403 errors

## Other Information
This is a temporary workaround. The permanent fix requires resolving the DNS race condition with private endpoints during ARM deployments.